### PR TITLE
[FIX] 유효하지 않은 토큰 403 수정

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -30,18 +30,18 @@ export default (req: Request, res: Response, next: NextFunction) => {
     }
     if (decoded === exceptionMessage.TOKEN_INVALID) {
       return res
-        .status(statusCode.UNAUTHORIZED)
+        .status(statusCode.FORBIDDEN)
         .send(
-          BaseResponse.failure(statusCode.UNAUTHORIZED, message.INVALID_TOKEN),
+          BaseResponse.failure(statusCode.FORBIDDEN, message.INVALID_TOKEN),
         );
     }
 
     const userId = (decoded as JwtPayload).id;
     if (!userId) {
       return res
-        .status(statusCode.UNAUTHORIZED)
+        .status(statusCode.FORBIDDEN)
         .send(
-          BaseResponse.failure(statusCode.UNAUTHORIZED, message.INVALID_TOKEN),
+          BaseResponse.failure(statusCode.FORBIDDEN, message.INVALID_TOKEN),
         );
     }
     const user = User.findById(userId);


### PR DESCRIPTION
## Related issue 🚀
- closed #123

## Work Description 💚
- 유효하지 않은 토큰의 에러는 403 상태코드로 처리합니다.
